### PR TITLE
docs: Add NixOS installation guide with flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea*
+/result

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 
 A program for managing systemd services through a TUI (Terminal User Interfaces).
 
-This tool allows you to manage systemd services with ease. You can view logs, list services, view properties, and control their lifecycle—start, stop, restart, enable, and disable—using the D-Bus API. 
+This tool allows you to manage systemd services with ease. You can view logs, list services, view properties, and control their lifecycle—start, stop, restart, enable, and disable—using the D-Bus API.
 
 Additionally, it is possible to navigate between system and session units, choose to list either all units or only those of type 'service', and directly edit the selected unit's file. It also supports Vim-like navigation.
 
 ## Screenshots
+
 ![screenshot_list](https://raw.githubusercontent.com/matheus-git/systemd-manager-tui/main/assets/systemd-manager-tui.gif)
 View [screenshots](https://github.com/matheus-git/systemd-manager-tui/blob/main/docs/screenshots.md)
 
@@ -17,21 +18,56 @@ View [screenshots](https://github.com/matheus-git/systemd-manager-tui/blob/main/
 After installation, you can create an `alias` to make it easier to use.
 
 ### Ubuntu (recommended)
+
     sudo dpkg -i systemd-manager-tui_x.x.x-x_amd64.deb
+
 Download the .deb file from Releases
 
 ### Arch linux (recommended)
+
     yay -S systemd-manager-tui
+
 https://aur.archlinux.org/packages/systemd-manager-tui
 
+### NixOS (Quick Run)
+
+    nix run github:matheus-git/systemd-manager-tui
+
+### NixOS with flakes
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systemd-manager-tui.url = "github:matheus-git/systemd-manager-tui";
+  };
+
+  outputs = { self, nixpkgs, systemd-manager-tui, ... }: {
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        {
+          environment.systemPackages = [
+            systemd-manager-tui.packages.x86_64-linux.default
+          ];
+        }
+      ];
+    };
+  };
+}
+```
+
 ### Binary
+
     chmod +x systemd-manager-tui
     ./systemd-manager-tui
+
 Download binary from Releases
 
 ### Cargo
+
     cargo install --locked systemd-manager-tui
-        
+
 ## Main libraries
 
 - ratatui - 0.29.0

--- a/README.md
+++ b/README.md
@@ -33,29 +33,8 @@ https://aur.archlinux.org/packages/systemd-manager-tui
 
     nix run github:matheus-git/systemd-manager-tui
 
-### NixOS with flakes
-
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    systemd-manager-tui.url = "github:matheus-git/systemd-manager-tui";
-  };
-
-  outputs = { self, nixpkgs, systemd-manager-tui, ... }: {
-    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        {
-          environment.systemPackages = [
-            systemd-manager-tui.packages.x86_64-linux.default
-          ];
-        }
-      ];
-    };
-  };
-}
-```
+NixOS with flakes
+[Read here](docs/flakes.md)
 
 ### Binary
 

--- a/docs/flakes.md
+++ b/docs/flakes.md
@@ -1,0 +1,23 @@
+### Add this in your nixos config
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systemd-manager-tui.url = "github:matheus-git/systemd-manager-tui";
+  };
+
+  outputs = { self, nixpkgs, systemd-manager-tui, ... }: {
+    nixosConfigurations.yourhostname = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        {
+          environment.systemPackages = [
+            systemd-manager-tui.packages.x86_64-linux.default
+          ];
+        }
+      ];
+    };
+  };
+}
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751949589,
+        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9b008d60392981ad674e04016d25619281550a9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "A program for managing systemd services through a TUI (Terminal User Interfaces).";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+
+    forAllSystems = function: nixpkgs.lib.genAttrs systems (system: function nixpkgs.legacyPackages.${system});
+  in {
+    packages = forAllSystems (pkgs: rec {
+      default = systemd-manager-tui;
+      systemd-manager-tui = let
+        p = (pkgs.lib.importTOML ./Cargo.toml).package;
+        rev = self.dirtyRev or self.rev;
+      in
+        pkgs.rustPlatform.buildRustPackage {
+          pname = p.name;
+          inherit (p) version;
+
+          src = pkgs.lib.fileset.toSource {
+            root = ./.;
+            fileset = pkgs.lib.fileset.intersection (pkgs.lib.fileset.fromSource (pkgs.lib.sources.cleanSource ./.)) (
+              pkgs.lib.fileset.unions [
+                ./Cargo.toml
+                ./Cargo.lock
+                ./src
+              ]
+            );
+          };
+
+          cargoLock.lockFile = ./Cargo.lock;
+
+          buildInputs = [pkgs.openssl];
+          nativeBuildInputs = [pkgs.pkg-config];
+
+          env = {
+            BUILD_REV = rev;
+          };
+
+          meta = {
+            inherit (p) description homepage;
+            license = pkgs.lib.licenses.mit;
+            maintainers = with pkgs.lib.maintainers; [tuxdotrs];
+            mainProgram = "systemd-manager-tui";
+          };
+        };
+    });
+  };
+}


### PR DESCRIPTION
Added NixOS installation instructions to the README with both quick run (`nix run`) and flake install methods using proper flake inputs.

This makes the tool more accessible to NixOS users by providing both temporary and permanent installation options following modern Nix flake conventions.