### PR TITLE
fix: move timestamp fetch to background thread to prevent UI freeze

### DIFF
--- a/src/terminal/app.rs
+++ b/src/terminal/app.rs
@@ -51,7 +51,8 @@ pub enum Actions {
     EditCurrentService,
     ServiceAction(ServiceAction),
     ShowHelp,
-    Redraw
+    Redraw,
+    UpdateTimestamp(String, Option<u64>),
 }
 
 pub enum AppEvent {
@@ -233,6 +234,9 @@ impl App {
                 AppEvent::Action(Actions::ResetList) => {
                     self.table_service.set_usecase(self.usecases.clone());
                 },
+                AppEvent::Action(Actions::UpdateTimestamp(name, ts)) => {
+                    self.table_service.update_timestamp(name, ts);
+                }
                 AppEvent::Action(Actions::UpdateDetails | Actions::Redraw) => {}
                 AppEvent::Action(Actions::RefreshDetails) => {
                     if self.status == Status::Details {

--- a/src/usecases/services_manager.rs
+++ b/src/usecases/services_manager.rs
@@ -103,8 +103,8 @@ impl ServicesManager {
         self.repository.lock().unwrap().systemctl_cat(service.name())
     }
 
-    pub fn get_active_enter_timestamp(&self, name: &str) -> Result<u64, Box<dyn Error>> {
-        self.repository.lock().unwrap().get_active_enter_timestamp(name)
+    pub fn repository_handle(&self) -> Arc<Mutex<Box<dyn ServiceRepository>>> {
+        Arc::clone(&self.repository)
     }
 }
 


### PR DESCRIPTION
The runtime timestamp feature was fetching ActiveEnterTimestamp via two synchronous D-Bus calls (LoadUnit + Get) directly inside the render loop. This blocked the main thread, causing a noticeable freeze on startup before the TUI appeared, and on every selection change while scrolling.

How each concern is addressed:

1. TUI freezes before rendering: refresh_selected_timestamp() no longer blocks on D-Bus. It sends the service name to a channel and returns immediately, allowing the first render to complete without delay. The timestamp appears asynchronously once the worker delivers the result via UpdateTimestamp.

2. Timestamp fetch moved to a dedicated worker thread: spawn_timestamp_worker() creates a long-lived background thread that receives requests through an mpsc channel, fetches timestamps from the repository, and sends results back through the existing AppEvent channel.

3. Rapid scrolling no longer floods D-Bus with requests: The worker drains all queued requests before fetching, keeping only the latest one. If the user scrolls past 30 services while a fetch is in-flight, only the last service's timestamp is actually fetched. Additionally, update_timestamp() verifies the result still matches the currently selected service before applying it, discarding stale responses.